### PR TITLE
Add engagement push option for 'old' users

### DIFF
--- a/kinappserver/models/task2.py
+++ b/kinappserver/models/task2.py
@@ -750,7 +750,7 @@ def count_immediate_tasks(user_id, only_cat_id=None, send_push=True):
     # app_ver = user_app_data.app_ver
     # country_code = get_country_code_by_ip(user_app_data.ip_address)
 
-    user_next_tasks = get_next_tasks_for_user(user_id, send_push)
+    user_next_tasks = get_next_tasks_for_user(user_id, None, [], send_push)
 
     if only_cat_id:
         log.info('getting count_immediate_tasks for cat_id %s' % only_cat_id)

--- a/kinappserver/playbooks/roles/kin-app-server-cron/tasks/main.yml
+++ b/kinappserver/playbooks/roles/kin-app-server-cron/tasks/main.yml
@@ -17,13 +17,6 @@
   run_once: true # runs every day at 15 gmt on one machine
 
 - cron:
-    name: "send daily push messages - engage-week"
-    hour: 18
-    minute: 0
-    job: 'curl localhost:80/internal/engagement/send -H "Content-Type: application/json" -XPOST -d''{"scheme":"engage-week", "dryrun":"False"}'''
-  run_once: true # runs every day at 18 gmt on one machine
-
-- cron:
     name: "replenish blackhawk cards"
     job: "/opt/kin-app-server/kinappserver/cron/replenish_blackhawk_cards.sh"
   run_once: true # runs every minute, on one machine of the 2


### PR DESCRIPTION
- unified engage-recent and engage-week schemes. These can be calculated
together once every day (removed engage-week scheme)
- added engage-old scheme
- minor changes in logs